### PR TITLE
docs(community): remove Google+ link

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -79,7 +79,6 @@ html
           li: a(href='https://github.com/koajs/examples') Examples
           li: a(href='https://github.com/koajs/koa/wiki') Middleware
           li: a(href='https://github.com/koajs/koa/wiki') Wiki
-          li: a(href='https://plus.google.com/communities/101845768320796750641') G+ Community
           li: a(href='https://groups.google.com/forum/#!forum/koajs') Mailing list
           li: a(href='https://github.com/koajs/koa/blob/master/docs/guide.md') Guide
           li: a(href='https://github.com/koajs/koa/blob/master/docs/faq.md') FAQ


### PR DESCRIPTION
Hi,
I noticed that the Google+ link doesn't work anymore. Google+ was shutdown for consumers.