### PR TITLE
Optimize Google Fonts usage: subset, preconnect

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -4,7 +4,9 @@ html
     title Koa - next generation web framework for node.js
     link(rel='stylesheet', href='public/style.css')
     link(rel='stylesheet', href='public/icons/css/slate.css')
-    link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Italiana&subset=latin')
+    link(rel='preconnect' href='https://fonts.googleapis.com')
+    link(rel='preconnect' href='https://fonts.gstatic.com' crossorigin)
+    link(rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Italiana&display=swap&text=koa')
     link(rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/github.min.css')
     meta(name='viewport', content='user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0')
     script.


### PR DESCRIPTION
Currently, to show the koa logo it takes 10 KB. It could be optimized to request only 848 bytes by subsetting the font not just to `latin`, but to `koa` letters only. Additionally, it’s good to preconnect to external Google servers for better performance.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.